### PR TITLE
feat: get date message groups for muc

### DIFF
--- a/projects/pazznetwork/ngx-chat/src/lib/services/adapters/xmpp/plugins/multi-user-chat.plugin.ts
+++ b/projects/pazznetwork/ngx-chat/src/lib/services/adapters/xmpp/plugins/multi-user-chat.plugin.ts
@@ -4,7 +4,7 @@ import { Element } from 'ltx';
 import { BehaviorSubject, Subject } from 'rxjs';
 import { ContactMetadata } from '../../../../core/contact';
 import { Direction, Message } from '../../../../core/message';
-import { MessageStore } from '../../../../core/message-store';
+import { DateMessagesGroup, MessageStore } from '../../../../core/message-store';
 import { IqResponseStanza, Stanza } from '../../../../core/stanza';
 import { LogService } from '../../../log.service';
 import { AbstractStanzaBuilder } from '../abstract-stanza-builder';
@@ -64,6 +64,10 @@ export class Room {
         this.messageStore.addMessage(message);
     }
 
+    get dateMessagesGroups(): DateMessagesGroup[] {
+        return this.messageStore.dateMessageGroups;
+    }
+    
 }
 
 class RoomMessageStanzaBuilder extends AbstractStanzaBuilder {


### PR DESCRIPTION
![beispiel](https://user-images.githubusercontent.com/54836876/101752294-a40fb200-3ad1-11eb-9541-dc3dd0fb4236.PNG)

`get dateMessagesGroups(): DateMessagesGroup[] {
        return this.messageStore.dateMessageGroups;
}`

Added get dateMessagesGroups() for multi-user-chat.plugin.ts so you can actually get the DateMessagesGroups[] for MUC (because MessageStore is actually private). See picture for usage in 1v1 Chats. 

Greetings
DevRichter