### PR TITLE
refactor: add return types, use Maps, improve error handling

### DIFF
--- a/projects/pazznetwork/ngx-chat/src/lib/core/stanza.ts
+++ b/projects/pazznetwork/ngx-chat/src/lib/core/stanza.ts
@@ -8,10 +8,10 @@ export interface Stanza extends Element {
     name: string;
 }
 
-export interface IqResponseStanza extends Stanza {
+export interface IqResponseStanza<ResponseType extends 'result' | 'error' = 'result' | 'error'> extends Stanza {
     attrs: {
         id: string;
-        type: 'result' | 'error';
+        type: ResponseType;
         from?: string;
         to?: string;
     };

--- a/projects/pazznetwork/ngx-chat/src/lib/core/utils-array.ts
+++ b/projects/pazznetwork/ngx-chat/src/lib/core/utils-array.ts
@@ -7,7 +7,7 @@ export const toString: (elem: any) => string = elem => elem.toString();
  * @param list the list in which the element should be inserted
  * @param keyExtractor an optional element mapper, defaults to toString
  */
-export function insertSortedLast<U>(elemToInsert: U, list: U[], keyExtractor: (a: U) => any = toString) {
+export function insertSortedLast<U>(elemToInsert: U, list: U[], keyExtractor: (a: U) => any = toString): void {
     list.splice(findSortedInsertionIndexLast(keyExtractor(elemToInsert), list, keyExtractor), 0, elemToInsert);
 }
 
@@ -17,7 +17,7 @@ export function insertSortedLast<U>(elemToInsert: U, list: U[], keyExtractor: (a
  * @param haystack the pre sorted list
  * @param keyExtractor an optional needle mapper, defaults to toString
  */
-export function findSortedInsertionIndexLast<U, V>(needle: U, haystack: V[], keyExtractor: (a: V) => any = toString) {
+export function findSortedInsertionIndexLast<U, V>(needle: U, haystack: V[], keyExtractor: (a: V) => any = toString): number {
     let low = 0;
     let high = haystack.length;
 
@@ -39,7 +39,7 @@ export function findSortedInsertionIndexLast<U, V>(needle: U, haystack: V[], key
 /**
  * Find the index of an element in a sorted list. If list contains no matching element, return -1.
  */
-export function findSortedIndex<U, V>(needle: U, haystack: V[], keyExtractor: (a: V) => any = toString) {
+export function findSortedIndex<U, V>(needle: U, haystack: V[], keyExtractor: (a: V) => any = toString): number {
     let low = 0;
     let high = haystack.length;
 
@@ -64,7 +64,7 @@ export function findSortedIndex<U, V>(needle: U, haystack: V[], keyExtractor: (a
 /**
  * Like {@link Array.prototype.findIndex} but finds the last index instead.
  */
-export function findLastIndex<T>(arr: T[], predicate: (x: T) => boolean) {
+export function findLastIndex<T>(arr: T[], predicate: (x: T) => boolean): number {
     for (let i = arr.length - 1; i >= 0; i--) {
         if (predicate(arr[i])) {
             return i;
@@ -76,7 +76,7 @@ export function findLastIndex<T>(arr: T[], predicate: (x: T) => boolean) {
 /**
  * Like {@link Array.prototype.find} but finds the last matching element instead.
  */
-export function findLast<T>(arr: T[], predicate: (x: T) => boolean) {
+export function findLast<T>(arr: T[], predicate: (x: T) => boolean): T | undefined {
     return arr[findLastIndex(arr, predicate)];
 }
 

--- a/projects/pazznetwork/ngx-chat/src/lib/services/adapters/xmpp/iq-response.error.ts
+++ b/projects/pazznetwork/ngx-chat/src/lib/services/adapters/xmpp/iq-response.error.ts
@@ -1,0 +1,64 @@
+import { IqResponseStanza } from '../../../core/stanza';
+
+export class IqResponseError extends Error {
+    static readonly ERROR_ELEMENT_NS = 'urn:ietf:params:xml:ns:xmpp-stanzas';
+    readonly errorCode?: number;
+    readonly errorType?: string;
+    readonly errorCondition?: string;
+
+    constructor(readonly errorStanza: IqResponseStanza<'error'>) {
+        super(
+            IqResponseError.extractErrorTextFromErrorResponse(
+                errorStanza,
+                IqResponseError.extractErrorDataFromErrorResponse(errorStanza)
+            )
+        );
+
+        const {code, type, condition} = IqResponseError.extractErrorDataFromErrorResponse(errorStanza);
+        this.errorCode = code;
+        this.errorType = type;
+        this.errorCondition = condition;
+    }
+
+    private static extractErrorDataFromErrorResponse(stanza: IqResponseStanza<'error'>): {
+        code?: number,
+        type?: string,
+        condition?: string
+    } {
+        const errorElement = stanza.getChild('error');
+        const errorCode = Number(errorElement?.attrs.code) || undefined;
+        const errorType = errorElement?.attrs.type as string | undefined;
+        const errorCondition =
+            errorElement
+                ?.children
+                .filter(childElement =>
+                    childElement.getName() !== 'text' &&
+                    childElement.attrs.xmlns === IqResponseError.ERROR_ELEMENT_NS
+                )[0]
+                ?.getName();
+
+        return {
+            code: errorCode,
+            type: errorType,
+            condition: errorCondition,
+        };
+    }
+
+    private static extractErrorTextFromErrorResponse(
+        stanza: IqResponseStanza<'error'>,
+        {code, type, condition}: {
+            code?: number,
+            type?: string,
+            condition?: string
+        }): string {
+        const additionalData = [
+            `errorCode: ${code ?? '[unknown]'}`,
+            `errorType: ${type ?? '[unknown]'}`,
+            `errorCondition: ${condition ?? '[unknown]'}`
+        ].join(', ');
+        const errorText =
+            stanza.getChild('error')?.getChildText('text', IqResponseError.ERROR_ELEMENT_NS) || 'Unknown error';
+
+        return `IqResponseError: ${errorText}${additionalData ? ` (${additionalData})` : ''}`;
+    }
+}

--- a/projects/pazznetwork/ngx-chat/src/lib/services/adapters/xmpp/plugins/http-file-upload.plugin.ts
+++ b/projects/pazznetwork/ngx-chat/src/lib/services/adapters/xmpp/plugins/http-file-upload.plugin.ts
@@ -14,15 +14,15 @@ export class HttpFileUploadPlugin extends AbstractXmppPlugin {
     private uploadService: Promise<Service>;
 
     constructor(
-        private httpClient: HttpClient,
-        private serviceDiscoveryPlugin: ServiceDiscoveryPlugin,
-        private xmppChatAdapter: XmppChatAdapter,
-        private logService: LogService
+        private readonly httpClient: HttpClient,
+        private readonly serviceDiscoveryPlugin: ServiceDiscoveryPlugin,
+        private readonly xmppChatAdapter: XmppChatAdapter,
+        private readonly logService: LogService
     ) {
         super();
     }
 
-    onBeforeOnline(): PromiseLike<any> {
+    onBeforeOnline(): Promise<void> {
         this.uploadService = this.serviceDiscoveryPlugin.findService('store', 'file');
         this.uploadService.then(() => {
             this.fileUploadSupported = true;
@@ -33,19 +33,19 @@ export class HttpFileUploadPlugin extends AbstractXmppPlugin {
         return Promise.resolve();
     }
 
-    onOffline() {
+    onOffline(): void {
         this.uploadService = null;
         this.fileUploadSupported = false;
     }
 
-    async upload(file: File) {
+    async upload(file: File): Promise<string> {
         await this.uploadService;
         const {name, size, type} = file;
         const slotUrl = await this.requestSlot(name, size.toString(), type);
-        return this.uploadToSlot(slotUrl, file);
+        return await this.uploadToSlot(slotUrl, file);
     }
 
-    private async requestSlot(filename: string, size: string, contentType: string) {
+    private async requestSlot(filename: string, size: string, contentType: string): Promise<string | undefined> {
         const to = (await this.uploadService).jid;
         const slotResponse = await this.xmppChatAdapter.chatConnectionService.sendIq(
             xml('iq', {to, type: 'get'},

--- a/projects/pazznetwork/ngx-chat/src/lib/services/adapters/xmpp/plugins/message-archive.plugin.ts
+++ b/projects/pazznetwork/ngx-chat/src/lib/services/adapters/xmpp/plugins/message-archive.plugin.ts
@@ -3,7 +3,7 @@ import { Element } from 'ltx';
 import { Subject } from 'rxjs';
 import { debounceTime, filter } from 'rxjs/operators';
 import { Recipient } from '../../../../core/recipient';
-import { IqResponseStanza, Stanza } from '../../../../core/stanza';
+import { Stanza } from '../../../../core/stanza';
 import { LogService } from '../../../log.service';
 import { XmppChatAdapter } from '../xmpp-chat-adapter.service';
 import { AbstractXmppPlugin } from './abstract-xmpp-plugin';
@@ -158,7 +158,7 @@ export class MessageArchivePlugin extends AbstractXmppPlugin {
                 this.mamMessageReceived$.next();
             }
         } else if (type === 'groupchat') {
-            this.multiUserChatPlugin.handleRoomMessageStanza(messageElement, delayEl);
+            this.multiUserChatPlugin.handleStanza(messageElement, delayEl);
         } else {
             throw new Error(`unknown archived message type: ${type}`);
         }

--- a/projects/pazznetwork/ngx-chat/src/lib/services/adapters/xmpp/plugins/message.plugin.ts
+++ b/projects/pazznetwork/ngx-chat/src/lib/services/adapters/xmpp/plugins/message.plugin.ts
@@ -41,9 +41,9 @@ export class MessagePlugin extends AbstractXmppPlugin {
 
         const messageFromArchive = archiveDelayElement != null;
 
-        const delay = archiveDelayElement ?? messageStanza.getChild('delay');
-        const datetime = delay && delay.attrs.stamp
-            ? new Date(delay.attrs.stamp)
+        const delayElement = archiveDelayElement ?? messageStanza.getChild('delay');
+        const datetime = delayElement?.attrs.stamp
+            ? new Date(delayElement.attrs.stamp)
             : new Date() /* TODO: replace with entity time plugin */;
 
         if (messageDirection === Direction.in && !messageFromArchive) {
@@ -54,7 +54,7 @@ export class MessagePlugin extends AbstractXmppPlugin {
             body: messageStanza.getChildText('body').trim(),
             direction: messageDirection,
             datetime,
-            delayed: !!delay,
+            delayed: !!delayElement,
             fromArchive: messageFromArchive
         };
 

--- a/projects/pazznetwork/ngx-chat/src/lib/services/adapters/xmpp/plugins/muc-sub.plugin.ts
+++ b/projects/pazznetwork/ngx-chat/src/lib/services/adapters/xmpp/plugins/muc-sub.plugin.ts
@@ -7,15 +7,15 @@ import { Stanza } from '../../../../core/stanza';
 
 export const MUC_SUB_FEATURE_ID = 'urn:xmpp:mucsub:0';
 
-export const MUC_SUB_EVENT_TYPE = Object.freeze({
-    presence: 'urn:xmpp:mucsub:nodes:presence',
-    messages: 'urn:xmpp:mucsub:nodes:messages',
-    affiliations: 'urn:xmpp:mucsub:nodes:affiliations',
-    subscribers: 'urn:xmpp:mucsub:nodes:subscribers',
-    config: 'urn:xmpp:mucsub:nodes:config',
-    subject: 'urn:xmpp:mucsub:nodes:subject',
-    system: 'urn:xmpp:mucsub:nodes:system'
-} as const);
+export enum MUC_SUB_EVENT_TYPE {
+    presence = 'urn:xmpp:mucsub:nodes:presence',
+    messages = 'urn:xmpp:mucsub:nodes:messages',
+    affiliations = 'urn:xmpp:mucsub:nodes:affiliations',
+    subscribers = 'urn:xmpp:mucsub:nodes:subscribers',
+    config = 'urn:xmpp:mucsub:nodes:config',
+    subject = 'urn:xmpp:mucsub:nodes:subject',
+    system = 'urn:xmpp:mucsub:nodes:system',
+}
 
 /**
  * support for https://docs.ejabberd.im/developer/xmpp-clients-bots/extensions/muc-sub/

--- a/src/app/multi-user-chat/multi-user-chat.component.ts
+++ b/src/app/multi-user-chat/multi-user-chat.component.ts
@@ -1,4 +1,4 @@
-import { Component, Inject, OnInit } from '@angular/core';
+import { Component, Inject } from '@angular/core';
 import {
     ChatService,
     ChatServiceToken,
@@ -16,7 +16,7 @@ import { jid } from '@xmpp/client';
     templateUrl: './multi-user-chat.component.html',
     styleUrls: ['./multi-user-chat.component.css']
 })
-export class MultiUserChatComponent implements OnInit {
+export class MultiUserChatComponent {
 
     multiUserChatPlugin: MultiUserChatPlugin;
     mucSubPlugin: MucSubPlugin;
@@ -24,14 +24,11 @@ export class MultiUserChatComponent implements OnInit {
     selectedRoom: Room;
     allRooms: RoomSummary[] = [];
     newRoom?: RoomCreationOptions;
-    mucSubSubscriptions: Map<string, string[]> = new Map();
+    mucSubSubscriptions = new Map<string, string[]>();
 
     constructor(@Inject(ChatServiceToken) public chatService: ChatService) {
         this.multiUserChatPlugin = chatService.getPlugin(MultiUserChatPlugin);
         this.mucSubPlugin = chatService.getPlugin(MucSubPlugin);
-    }
-
-    ngOnInit() {
     }
 
     async joinRoom(roomJid: string) {

--- a/src/app/routes/index/index.component.ts
+++ b/src/app/routes/index/index.component.ts
@@ -20,14 +20,14 @@ import {
 })
 export class IndexComponent {
 
-    public domain: string;
-    public service: string;
-    public password: string;
-    public username: string;
-    public otherJid: any;
-    public multiUserChatPlugin: MultiUserChatPlugin;
-    public unreadMessageCountPlugin: UnreadMessageCountPlugin;
-    public registrationMessage: string;
+    public domain?: string;
+    public service?: string;
+    public password?: string;
+    public username?: string;
+    public otherJid?: string;
+    public readonly multiUserChatPlugin: MultiUserChatPlugin;
+    public readonly unreadMessageCountPlugin: UnreadMessageCountPlugin;
+    public registrationMessage?: string;
 
     constructor(
         @Inject(ChatServiceToken) public chatService: ChatService,
@@ -36,7 +36,12 @@ export class IndexComponent {
         private chatListStateService: ChatListStateService,
         chatBackgroundNotificationService: ChatBackgroundNotificationService,
     ) {
-        const contactData: any = JSON.parse(localStorage.getItem('data')) || {};
+        const contactData: {
+            domain?: string;
+            service?: string;
+            password?: string;
+            username?: string;
+        } = JSON.parse(localStorage.getItem('data')) || {};
         this.logService.logLevel = LogLevel.Debug;
         this.domain = contactData.domain;
         this.service = contactData.service;


### PR DESCRIPTION
- add missing return type declarations to (some) methods
- consistently use `Map`s instead of plain `Object`s to avoid collisions with prototype properties & prevent prototype pollution issues
- improve error handling by creating explicit errors instead of rejecting with plain strings
- use functional array APIs instead of imperative loops where appropriate
- use modern language features to simplify some code