### PR TITLE
fix: fixed identities by mapping them to element.attrs

### DIFF
--- a/angular.json
+++ b/angular.json
@@ -87,7 +87,7 @@
             "main": "demo/test.ts",
             "polyfills": "demo/polyfills.ts",
             "tsConfig": "tsconfig.spec.json",
-            "karmaConfig": "demo/karma.conf.js",
+            "karmaConfig": "karma.conf.js",
             "assets": [
               "demo/favicon.ico",
               "demo/assets"

--- a/src/lib/services/adapters/xmpp/plugins/service-discovery.plugin.ts
+++ b/src/lib/services/adapters/xmpp/plugins/service-discovery.plugin.ts
@@ -133,7 +133,11 @@ export class ServiceDiscoveryPlugin extends AbstractXmppPlugin {
 
         const queryNode = serviceInformationResponse.getChild('query');
         const features = queryNode.getChildren('feature').map((featureNode: Element) => featureNode.attrs.var);
-        const identities = queryNode.getChildren('identity').filter((identityNode: Element) => identityNode.attrs);
+        const identities = queryNode
+            .getChildren('identity')
+            .filter((identityNode: Element) => identityNode.attrs)
+            .map((identityNode: Element) => identityNode.attrs);
+
         const serviceInformation: Service = {
             identities: this.isIdentities(identities) ? identities : [],
             features,

--- a/src/lib/services/adapters/xmpp/plugins/service-discovery.plugin.ts
+++ b/src/lib/services/adapters/xmpp/plugins/service-discovery.plugin.ts
@@ -24,7 +24,7 @@ class QueryStanzaBuilder extends AbstractStanzaBuilder {
 
 }
 
-export interface Identity {
+export interface IdentityAttrs {
     category: string;
     type: string;
     name?: string;
@@ -32,7 +32,7 @@ export interface Identity {
 
 export interface Service {
     jid: string;
-    identities: Identity[];
+    identitiesAttrs: IdentityAttrs[];
     features: string[];
 }
 
@@ -89,7 +89,8 @@ export class ServiceDiscoveryPlugin extends AbstractXmppPlugin {
 
             this.servicesInitialized$.pipe(first(value => !!value)).subscribe(() => {
                 const results = this.hostedServices.filter(service =>
-                    service.identities.filter(identity => identity.category === category && identity.type === type).length > 0,
+                    service.identitiesAttrs.filter(identityAttrs => identityAttrs.category === category
+                        && identityAttrs.type === type).length > 0,
                 );
 
                 if (results.length === 0) {
@@ -133,13 +134,13 @@ export class ServiceDiscoveryPlugin extends AbstractXmppPlugin {
 
         const queryNode = serviceInformationResponse.getChild('query');
         const features = queryNode.getChildren('feature').map((featureNode: Element) => featureNode.attrs.var);
-        const identities = queryNode
+        const identitiesAttrs = queryNode
             .getChildren('identity')
             .filter((identityNode: Element) => identityNode.attrs)
             .map((identityNode: Element) => identityNode.attrs);
 
         const serviceInformation: Service = {
-            identities: this.isIdentities(identities) ? identities : [],
+            identitiesAttrs: this.isIdentitiesAttrs(identitiesAttrs) ? identitiesAttrs : [],
             features,
             jid: serviceInformationResponse.attrs.from,
         };
@@ -147,7 +148,7 @@ export class ServiceDiscoveryPlugin extends AbstractXmppPlugin {
         return serviceInformation;
     }
 
-    private isIdentities(elements: { [attrName: string]: any }[]): elements is Identity[] {
+    private isIdentitiesAttrs(elements: { [attrName: string]: any }[]): elements is IdentityAttrs[] {
         return elements.every((element) => {
             const keys = Object.keys(element);
             const mustHave = keys.includes('category') && keys.includes('type');


### PR DESCRIPTION
Fixed the failing karma test in `service-discovery.plugin.spec.ts` with mapping the identities to `element.attrs`.