### PR TITLE
fix: missing Sending status

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,13 @@
+<a name="0.14.15"></a>
+## [0.14.15](https://github.com/pazznetwork/ngx-chat/compare/v0.14.14...v0.14.15) (2022-10-27)
+
+
+### Bug Fixes
+
+* missing Sending status ([fe97333](https://github.com/pazznetwork/ngx-chat/commit/fe97333))
+
+
+
 <a name="0.14.14"></a>
 ## [0.14.14](https://github.com/pazznetwork/ngx-chat/compare/v0.14.13...v0.14.14) (2022-10-24)
 

--- a/README.md
+++ b/README.md
@@ -210,7 +210,7 @@ For clean and standardised commit messages we use commit lint, for the format se
 
 ```bash
 # increment version number in projects/pazznetwork/ngx-chat/package.json
-VERSION=0.14.13 # change accordingly
+VERSION=0.14.15 # change accordingly
 npm run changelog
 git add .
 git commit -m "docs: release $VERSION"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pazznetwork/ngx-chat",
-  "version": "0.14.14",
+  "version": "0.14.15",
   "license": "MIT",
   "scripts": {
     "ng": "ng",

--- a/src/lib/components/chat-message/chat-message.component.ts
+++ b/src/lib/components/chat-message/chat-message.component.ts
@@ -95,10 +95,25 @@ export class ChatMessageComponent implements OnInit {
 
         if (this.showMessageReadState && this.messageStatePlugin && this.contact) {
             const date = this.message.datetime;
-            const states = this.messageStatePlugin.getContactMessageState(this.contact.jidBare.toString());
-            return this.getStateForDate(date, states);
+            const jid = this.contact.jidBare.toString();
+            const states = this.messageStatePlugin.getContactMessageState(jid);
+            const messageState = this.getStateForDate(date, states);
+            this.handleSendingStatus(messageState, jid);
+            return messageState;
         }
         return undefined;
+    }
+
+    private handleSendingStatus = (messageState: MessageState, jid: string) => {
+        if (messageState === MessageState.SENDING) {
+            this.messageStatePlugin.updateContactMessageState(
+                jid,
+                MessageState.SENT,
+            );
+        }
+        // run once per message
+        this.handleSendingStatus = () => {
+        };
     }
 
     private getStateForDate(date: Date, states: StateDate): MessageState | undefined {


### PR DESCRIPTION
How to reproduce error:

1. Log-in to the chat 
2. Block internet connection (using devtools)
3. Send message.

Actual: instantly added ✓indicator
Excepted: no ✓ indicator (until the connection is re-established)